### PR TITLE
Comment out line causing circular import error

### DIFF
--- a/sri_maper/src/utils/posthoc_utils.py
+++ b/sri_maper/src/utils/posthoc_utils.py
@@ -3,7 +3,7 @@ from torch import nn, optim
 from itertools import islice
 import numpy as np
 
-from sri_maper.src.models.cma_module import CMALitModule
+# from sri_maper.src.models.cma_module import CMALitModule
 from sri_maper.src import utils
 log = utils.get_pylogger(__name__)
 


### PR DESCRIPTION
This circular import issue is still coming up when MTRI tries to run SRI code from within our plugin. Since it's a simple fix, I thought I'd go ahead and put in a pull request for it.